### PR TITLE
Corrected default value (fixes #9), replaced now deprecated function create_function()

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -470,7 +470,7 @@ class aspirelist {
         }
         $codes = array_unique($codes);
 
-        return array_map(create_function('$code', 'return array(\'code\' => $code);'), $codes);
+        return array_map(function($code) {return array('code' => $code);}, $codes);
     }
 
     /**
@@ -582,7 +582,7 @@ class aspirelist {
         unset($codes);
 
         // Sort the lists by name.
-        $keys = array_map(create_function('$a', 'return strtolower($a->name);'), $lists);
+        $keys = array_map(function($a) {return strtolower($a->name);}, $lists);
         array_multisort($keys, SORT_ASC, SORT_STRING, $lists);
 
         return $lists;

--- a/settings.php
+++ b/settings.php
@@ -39,7 +39,7 @@ if ($ADMIN->fulltree) {
     $optionsdd[0] = get_string('displaypage', 'aspirelist');
     $optionsdd[1] = get_string('displayinline', 'aspirelist');
     $settings->add(new admin_setting_configselect('aspirelist/defaultdisplay', get_string('defaultdisplay', 'aspirelist'),
-            get_string('defaultdisplay_desc', 'aspirelist'), 'displaypage', $optionsdd));
+            get_string('defaultdisplay_desc', 'aspirelist'), 0, $optionsdd));
 
     // Authors in module config form.
     $settings->add(new admin_setting_configcheckbox('aspirelist/authorsinconfig', get_string('authorsinconfig', 'aspirelist'),


### PR DESCRIPTION
When running Behat test this one (completion/test/behat/default_activity_completion.feature)) throws an error:

> Exception - Warning: Undefined property: stdClass::$defaultdisplay in [dirroot]/mod/aspirelist/mod_form.php on line 105

The reason for this is a faulty default value for defaultdisplay in settings which will prevent a value to be written into the database table. I now provide a numerical value for the default setting. This will address issue #9.

I also replaced the now deprecated function create_function().